### PR TITLE
feat: disable upvote button when no votes are left

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,6 @@
 - add semantic release
 - create / join buttons style and placement
 - add possibility for moderator to activate / deactivate voting retro cards
-- convert margins, paddings, etc. to theme.spacing (which is 8 by default)
 
 # Refactorings
 

--- a/TODO.md
+++ b/TODO.md
@@ -9,8 +9,8 @@
 # Improvement
 
 - add semantic release
-- What happened to column widths?
 - create / join buttons style and placement
+- add possibility for moderator to activate / deactivate voting retro cards
 
 # Refactorings
 

--- a/TODO.md
+++ b/TODO.md
@@ -11,6 +11,7 @@
 - add semantic release
 - create / join buttons style and placement
 - add possibility for moderator to activate / deactivate voting retro cards
+- convert margins, paddings, etc. to theme.spacing (which is 8 by default)
 
 # Refactorings
 

--- a/packages/frontend/src/retro/components/cards/UpvoteCardButton.tsx
+++ b/packages/frontend/src/retro/components/cards/UpvoteCardButton.tsx
@@ -23,7 +23,12 @@ export function UpvoteCardButton({ columnIndex, card, ...props }: UpvoteItemButt
   }
 
   return (
-    <CardActionButton {...props} onClick={handleUpvote} tooltipText="Upvote Card">
+    <CardActionButton
+      {...props}
+      disabled={votesLeft === 0}
+      onClick={handleUpvote}
+      tooltipText="Upvote Card"
+    >
       <ThumbUp />
     </CardActionButton>
   );


### PR DESCRIPTION
# Disable retro upvote button when no votes are left

## Description

The upvote button not being disabled when all votes are already spent did not reflect the buttons functionality. Also a solved todo item was removed and a new item was added.