### PR TITLE
feat: implement Start / Stop Voting Button for moderators in retro 

### DIFF
--- a/packages/frontend/src/retro/components/RetroActionButtons.tsx
+++ b/packages/frontend/src/retro/components/RetroActionButtons.tsx
@@ -7,6 +7,7 @@ import { useUserContext } from "../../common/context/UserContext";
 import { SetupSessionButton } from "../../common/components/buttons/SetupSessionButton";
 import { ToggleRetroBlurButton } from "./buttons/ToggleRetroBlurButton";
 import { CreateColumnButton } from "./buttons/CreateColumnButton";
+import { ToggleRetroVotingButton } from "./ToggleRetroVotingButton";
 
 export function RetroActionButtons() {
   const { user } = useUserContext();
@@ -36,6 +37,9 @@ export function RetroActionButtons() {
       </Grid>
       <Grid item>
         <ToggleRetroBlurButton />
+      </Grid>
+      <Grid item>
+        <ToggleRetroVotingButton />
       </Grid>
     </Grid>
   );

--- a/packages/frontend/src/retro/components/RetroTitle.tsx
+++ b/packages/frontend/src/retro/components/RetroTitle.tsx
@@ -5,5 +5,5 @@ import { useRetroContext } from "../context/RetroContext";
 export function RetroTitle() {
   const { retroState } = useRetroContext();
 
-  return <Typography variant="h5">{retroState.title}</Typography>;
+  return <Typography variant="h4">{retroState.title}</Typography>;
 }

--- a/packages/frontend/src/retro/components/ToggleRetroVotingButton.tsx
+++ b/packages/frontend/src/retro/components/ToggleRetroVotingButton.tsx
@@ -1,0 +1,23 @@
+import { ActionButton } from "../../common/components/buttons/ActionButton";
+import React from "react";
+import { PlayArrow, Stop } from "@mui/icons-material";
+import { useRetroContext } from "../context/RetroContext";
+import { isModerator } from "../../common/utils/participantsUtils";
+import { useUserContext } from "../../common/context/UserContext";
+
+export function ToggleRetroVotingButton() {
+  const { retroState, handleIsVotingEnabledChanged } = useRetroContext();
+  const { isVotingEnabled } = retroState;
+  const { user } = useUserContext();
+
+  const buttonText = isVotingEnabled ? "Stop Voting" : "Start Voting";
+  const buttonIcon = isVotingEnabled ? <Stop /> : <PlayArrow />;
+
+  function toggleIsVotingEnabled() {
+    handleIsVotingEnabledChanged(!isVotingEnabled);
+  }
+
+  if (!isModerator(user)) return null;
+
+  return <ActionButton onClick={toggleIsVotingEnabled} label={buttonText} icon={buttonIcon} />;
+}

--- a/packages/frontend/src/retro/components/ToggleRetroVotingButton.tsx
+++ b/packages/frontend/src/retro/components/ToggleRetroVotingButton.tsx
@@ -14,6 +14,7 @@ export function ToggleRetroVotingButton() {
   const buttonIcon = isVotingEnabled ? <Stop /> : <PlayArrow />;
 
   function toggleIsVotingEnabled() {
+    if (!isModerator(user)) return;
     handleIsVotingEnabledChanged(!isVotingEnabled);
   }
 

--- a/packages/frontend/src/retro/components/VoteProgress.tsx
+++ b/packages/frontend/src/retro/components/VoteProgress.tsx
@@ -8,10 +8,10 @@ import { useVotesLeft } from "../hooks/useVotesLeft";
 export function VoteProgress() {
   const { user } = useUserContext();
   const { retroState } = useRetroContext();
-  const { maxVoteCount } = retroState;
+  const { maxVoteCount, isVotingEnabled } = retroState;
   const votesLeft = useVotesLeft();
 
-  if (!user.id) return null;
+  if (!user.id || !isVotingEnabled) return null;
 
   return (
     <Box px={2} display="flex" alignItems="center">

--- a/packages/frontend/src/retro/components/buttons/ImportRetroMenuItem.tsx
+++ b/packages/frontend/src/retro/components/buttons/ImportRetroMenuItem.tsx
@@ -24,7 +24,12 @@ export function ImportRetroMenuItem() {
 
     const retroJson = await file.text();
     const importedRetro: RetroSchemaV1 = JSON.parse(retroJson);
-    const retro: RetroState = { ...importedRetro, participants: {}, waitingList: {} };
+    const retro: RetroState = {
+      ...importedRetro,
+      participants: {},
+      waitingList: {},
+      isVotingEnabled: false,
+    };
     handleSetRetroState(retro);
   }
 

--- a/packages/frontend/src/retro/components/cards/RetroCardActions.tsx
+++ b/packages/frontend/src/retro/components/cards/RetroCardActions.tsx
@@ -6,6 +6,7 @@ import { MarkAsDiscussedButton } from "./MarkAsDiscussedButton";
 import { DeleteCardButton } from "./DeleteCardButton";
 import { RemoveUpvoteCardButton } from "./RemoveUpvoteCardButton";
 import { UpvoteCardButton } from "./UpvoteCardButton";
+import { useRetroContext } from "../../context/RetroContext";
 
 interface RetroCardActionsProps {
   card: RetroCard;
@@ -15,13 +16,23 @@ interface RetroCardActionsProps {
 
 export function RetroCardActions({ card, columnIndex, isBlurred }: RetroCardActionsProps) {
   const { user } = useUserContext();
+  const { retroState } = useRetroContext();
+  const { isVotingEnabled } = retroState;
 
   const isButtonDisabled = isBlurred && user.role === "participant";
 
   return (
     <div>
-      <UpvoteCardButton disabled={isButtonDisabled} card={card} columnIndex={columnIndex} />
-      <RemoveUpvoteCardButton disabled={isButtonDisabled} card={card} columnIndex={columnIndex} />
+      {isVotingEnabled && (
+        <>
+          <UpvoteCardButton disabled={isButtonDisabled} card={card} columnIndex={columnIndex} />
+          <RemoveUpvoteCardButton
+            disabled={isButtonDisabled}
+            card={card}
+            columnIndex={columnIndex}
+          />
+        </>
+      )}
       <EditCardButton disabled={isButtonDisabled} card={card} columnIndex={columnIndex} />
       <MarkAsDiscussedButton disabled={isButtonDisabled} card={card} columnIndex={columnIndex} />
       <DeleteCardButton disabled={isButtonDisabled} card={card} columnIndex={columnIndex} />

--- a/packages/frontend/src/retro/context/RetroContext.tsx
+++ b/packages/frontend/src/retro/context/RetroContext.tsx
@@ -45,6 +45,7 @@ const initialState: RetroState = {
   maxVoteCount: 3,
   participants: {},
   waitingList: {},
+  isVotingEnabled: false,
 };
 
 export interface RetroContextValues {
@@ -76,6 +77,7 @@ export interface RetroContextValues {
   handleRejectJoinUser: (userId: string) => void;
   handleAcceptJoinUser: (userId: string) => void;
   handleAddToWaitingList: (payload: AddToWaitingListAction["payload"]) => void;
+  handleIsVotingEnabledChanged: (isEnabled: boolean) => void;
 }
 
 export const RetroContext = React.createContext<RetroContextValues>(undefined!);
@@ -213,6 +215,10 @@ export function RetroContextProvider(props: RetroContextProviderProps) {
     dispatchAndBroadcast({ type: "TRANSFER_MODERATOR_ROLE", payload });
   }
 
+  function handleIsVotingEnabledChanged(isEnabled: boolean) {
+    dispatchAndBroadcast({ type: "IS_VOTING_ENABLED_CHANGED", isEnabled });
+  }
+
   const resetRetroState = useCallback(() => {
     dispatch({ type: "SET_RETRO_STATE", payload: initialState });
   }, []);
@@ -246,6 +252,7 @@ export function RetroContextProvider(props: RetroContextProviderProps) {
     handleRejectJoinUser: rejectJoinUser,
     handleAcceptJoinUser: acceptJoinUser,
     handleAddToWaitingList,
+    handleIsVotingEnabledChanged,
   };
 
   return <RetroContext.Provider value={value}>{props.children}</RetroContext.Provider>;

--- a/packages/frontend/src/retro/reducers/retroReducer.ts
+++ b/packages/frontend/src/retro/reducers/retroReducer.ts
@@ -221,6 +221,9 @@ export const retroReducer = (state: RetroState, action: RetroAction): RetroState
       );
       return { ...state, waitingList: remainingWaitingUsers };
     }
+    case "IS_VOTING_ENABLED_CHANGED": {
+      return { ...state, isVotingEnabled: action.isEnabled };
+    }
     case "DISCONNECT": {
       const { participants, waitingList } = state;
       const disconnectedUserId = action.payload;

--- a/packages/frontend/src/retro/types/retroActions.ts
+++ b/packages/frontend/src/retro/types/retroActions.ts
@@ -90,6 +90,11 @@ export interface ChangeRetroFormatAction extends BaseAction {
   payload: string;
 }
 
+export interface IsVotingEnabledChangedAction extends BaseAction {
+  type: "IS_VOTING_ENABLED_CHANGED";
+  isEnabled: boolean;
+}
+
 export type RetroAction =
   | PeerToPeerAction<RetroState>
   | CardUpvoteAction
@@ -109,4 +114,5 @@ export type RetroAction =
   | ToggleRetroBlurAction
   | ToggleCardDiscussedAction
   | ChangeRetroFormatAction
-  | SortCardsByVotesDescendingAction;
+  | SortCardsByVotesDescendingAction
+  | IsVotingEnabledChangedAction;

--- a/packages/frontend/src/retro/types/retroTypes.ts
+++ b/packages/frontend/src/retro/types/retroTypes.ts
@@ -26,6 +26,7 @@ export interface RetroState {
   highlightedCardId?: string;
   participants: UserByUserId;
   waitingList: UserByUserId;
+  isVotingEnabled: boolean;
 }
 
 export type VotesByUserId = Record<string, number>;


### PR DESCRIPTION
#  Start / Stop Voting Button for moderators in retro 
## Description
In order to focus on retro topics while there is no voting going on, the moderator can actively start and stop voting sessions. While voting is disabled: hide up-/downvote buttons on cards and VoteProgress.