### PR TITLE
fix: allow dependabot branch name prefix

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,7 +3,7 @@
 
 validate_branch_name() {
   local branch=$(git rev-parse --abbrev-ref HEAD)
-  local regex="^(feature|fix|hotfix|release|refactor|perf|tech|docs)\/[a-zA-Z0-9_]+(\/[a-zA-Z0-9_]+)*$"
+  local regex="^(feature|fix|hotfix|release|refactor|perf|tech|docs|dependabot)\/[a-zA-Z0-9_]+(\/[a-zA-Z0-9_]+)*$"
   if ! [[ $branch =~ $regex ]]; then
     echo "Your commit was rejected due to branching name"
     echo "Please rename your branch with '(feature|fix|hotfix|release|refactor|perf|tech|docs)/test_123' syntax"


### PR DESCRIPTION
(but not promote it in error message) in case we need to make changes to a dependabot branch

# Allow dependabot branch name prefix 

## Description

This PR
- allows developers to change code inside a dependabot PR branch and push it
- does not implement anything to show the "dependabot" prefix as a suggestion in the husky error message, because dev-created branches should not be prefixed with "dependabot".