### PR TITLE
fix: fix typo in all-contributors by adding name instead of username

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -93,7 +93,7 @@
     },
     {
       "login": "dostulataa",
-      "name": "dostualtaa",
+      "name": "Lukas Richter",
       "avatar_url": "https://avatars.githubusercontent.com/u/7762085?v=4",
       "profile": "https://github.com/dostulataa",
       "contributions": [


### PR DESCRIPTION
## Description

fix typo in all-contributors