### PR TITLE
feat: make cors origins configurable through environment variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "build": "nx run-many --targets=build --all",
     "build:frontend": "nx build frontend",
     "build:backend": "nx build backend",
-    "build:shared": "nx build shared",
     "start:backend": "nx start backend",
     "watch": "nx run-many --targets=build:watch --all",
     "frontend:dev": "nx start frontend",

--- a/packages/backend/src/setupServer.ts
+++ b/packages/backend/src/setupServer.ts
@@ -1,11 +1,12 @@
 import express from "express";
 import http from "http";
 import { Server, Socket } from "socket.io";
-import cors from "cors";
+import cors, { CorsOptions } from "cors";
 
 import { ClientToServerEvents, ServerToClientEvents } from "@shared/socket";
 import { ConnectionStore } from "./store/ConnectionStore";
 import { logger } from "@shared/logger";
+import { configuration } from "@shared/configuration";
 
 export function setupServer() {
   const app = express();
@@ -13,14 +14,16 @@ export function setupServer() {
 
   const connectionStore = new ConnectionStore();
 
+  const corsOptions: CorsOptions = {
+    origin: configuration.corsOrigins,
+  };
+
   const io = new Server<ClientToServerEvents, ServerToClientEvents>(server, {
-    cors: {
-      origin: "*", // TODO: add proper CORS config
-    },
+    cors: corsOptions,
     allowEIO3: true,
   });
 
-  app.use(cors());
+  app.use(cors(corsOptions));
 
   app.get("/:namespace/rooms/:roomId", (req, res) => {
     const { roomId, namespace } = req.params;

--- a/packages/shared/configuration/src/configuration.ts
+++ b/packages/shared/configuration/src/configuration.ts
@@ -1,6 +1,8 @@
 import { ApplicationConfiguration } from "./types";
 import { RetroAppUrl } from "./RetroAppUrl";
 
+export const configuration = getConfiguration();
+
 function getConfiguration(): ApplicationConfiguration {
   const backendUrl = new RetroAppUrl({
     protocol: process.env.REACT_APP_BACKEND_PROTOCOL ?? "http",
@@ -21,7 +23,14 @@ function getConfiguration(): ApplicationConfiguration {
     retro: {
       maxVoteCount: Number(process.env.REACT_APP_RETRO_MAX_VOTE_COUNT) ?? 3,
     },
+    corsOrigins: parseCorsOrigins(process.env.CORS_ORIGIN) ?? "*",
   };
 }
 
-export const configuration = getConfiguration();
+function parseCorsOrigins(list?: string): string[] | string | undefined {
+  if (!list) return undefined;
+
+  const origins = list.split(",").map((origin) => origin.trim());
+  if (origins.length <= 1) return list;
+  return origins;
+}

--- a/packages/shared/configuration/src/configuration.ts
+++ b/packages/shared/configuration/src/configuration.ts
@@ -1,4 +1,4 @@
-import { ApplicationConfiguration } from "./types";
+import { ApplicationConfiguration, CorsOrigins } from "./types";
 import { RetroAppUrl } from "./RetroAppUrl";
 
 export const configuration = getConfiguration();
@@ -27,7 +27,7 @@ function getConfiguration(): ApplicationConfiguration {
   };
 }
 
-function parseCorsOrigins(list?: string): string[] | string | undefined {
+function parseCorsOrigins(list?: string): CorsOrigins | undefined {
   if (!list) return undefined;
 
   const origins = list.split(",").map((origin) => origin.trim());

--- a/packages/shared/configuration/src/types.ts
+++ b/packages/shared/configuration/src/types.ts
@@ -5,6 +5,7 @@ export interface ApplicationConfiguration {
   backendUrl: RetroAppUrl;
   retro: RetroConfiguration;
   signalingServerUrl: RetroAppUrl;
+  corsOrigins: string | string[];
 }
 
 export interface RetroConfiguration {

--- a/packages/shared/configuration/src/types.ts
+++ b/packages/shared/configuration/src/types.ts
@@ -1,11 +1,13 @@
 import { RetroAppUrl } from "./RetroAppUrl";
 
+export type CorsOrigins = string | string[];
+
 export interface ApplicationConfiguration {
   logLevel: string;
   backendUrl: RetroAppUrl;
   retro: RetroConfiguration;
   signalingServerUrl: RetroAppUrl;
-  corsOrigins: string | string[];
+  corsOrigins: CorsOrigins;
 }
 
 export interface RetroConfiguration {


### PR DESCRIPTION
# Configurable CORS options

_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/retro/blob/master/CONTRIBUTING.md) before opening a PR.**_

## Description

Cors origins was set to `*` before. This is fine locally, but not in a deployed state. The cors origins can now be set through environment variables.