### PR TITLE
Removed static configuration variable

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -1,11 +1,11 @@
 import { setupServer } from "./setupServer";
 import { logger } from "@shared/logger";
 import dotenv from "dotenv";
-import { configuration } from "@shared/configuration";
+import { getConfiguration } from "@shared/configuration";
 
 dotenv.config();
 
-const serverPort = configuration.backendUrl.port;
+const serverPort = getConfiguration().backendUrl.port;
 
 const server = setupServer();
 

--- a/packages/backend/src/setupServer.ts
+++ b/packages/backend/src/setupServer.ts
@@ -6,7 +6,7 @@ import cors, { CorsOptions } from "cors";
 import { ClientToServerEvents, ServerToClientEvents } from "@shared/socket";
 import { ConnectionStore } from "./store/ConnectionStore";
 import { logger } from "@shared/logger";
-import { configuration } from "@shared/configuration";
+import { getConfiguration } from "@shared/configuration";
 
 export function setupServer() {
   const app = express();
@@ -15,7 +15,7 @@ export function setupServer() {
   const connectionStore = new ConnectionStore();
 
   const corsOptions: CorsOptions = {
-    origin: configuration.corsOrigins,
+    origin: getConfiguration().corsOrigins,
   };
 
   const io = new Server<ClientToServerEvents, ServerToClientEvents>(server, {

--- a/packages/frontend/src/common/utils/globalGetServerSideProps.ts
+++ b/packages/frontend/src/common/utils/globalGetServerSideProps.ts
@@ -1,5 +1,5 @@
 import { GetServerSideProps } from "next";
-import { ApplicationConfiguration, configuration } from "@shared/configuration";
+import { ApplicationConfiguration, getConfiguration } from "@shared/configuration";
 
 export interface GlobalGetServerSideProps {
   configuration: ApplicationConfiguration;
@@ -8,6 +8,6 @@ export interface GlobalGetServerSideProps {
 export const globalGetServerSideProps: GetServerSideProps<{
   configuration: ApplicationConfiguration;
 }> = async () => {
-  const parsedConfiguration = JSON.parse(JSON.stringify(configuration));
+  const parsedConfiguration = JSON.parse(JSON.stringify(getConfiguration()));
   return { props: { configuration: parsedConfiguration } };
 };

--- a/packages/frontend/src/pages/api/config.ts
+++ b/packages/frontend/src/pages/api/config.ts
@@ -1,9 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { ApplicationConfiguration, configuration } from "@shared/configuration";
+import { ApplicationConfiguration, getConfiguration } from "@shared/configuration";
 
 export default function handler(
   request: NextApiRequest,
   response: NextApiResponse<ApplicationConfiguration>
 ) {
-  response.status(200).json(configuration);
+  response.status(200).json(getConfiguration());
 }

--- a/packages/shared/configuration/src/configuration.ts
+++ b/packages/shared/configuration/src/configuration.ts
@@ -1,6 +1,5 @@
 import { ApplicationConfiguration, CorsOrigins, IceServerConfiguration, LogLevel } from "./types";
 import { RetroAppUrl } from "./RetroAppUrl";
-export const configuration = getConfiguration();
 
 export function getConfiguration(): ApplicationConfiguration {
   const backendUrl = new RetroAppUrl({

--- a/packages/shared/logger/src/logger.ts
+++ b/packages/shared/logger/src/logger.ts
@@ -1,5 +1,5 @@
 import { createLogger as createWinstonLogger, format, transports } from "winston";
-import { configuration } from "@shared/configuration";
+import { getConfiguration } from "@shared/configuration";
 
 const loggerFormat = format.combine(
   format.timestamp({
@@ -11,7 +11,7 @@ const loggerFormat = format.combine(
 );
 
 export const logger = createLogger({
-  logLevel: configuration.logLevel,
+  logLevel: getConfiguration().logLevel,
 });
 
 export function createLogger({ withConsolePipe = true, logLevel }: CreateLoggerOptions) {

--- a/packages/signaling/src/index.ts
+++ b/packages/signaling/src/index.ts
@@ -1,11 +1,11 @@
 import dotenv from "dotenv";
-import { configuration } from "@shared/configuration";
+import { getConfiguration } from "@shared/configuration";
 import { spawn } from "child_process";
 import { logger } from "@shared/logger";
 
 dotenv.config();
 
-const signalingServerPort = configuration.signalingServerUrl.port;
+const signalingServerPort = getConfiguration().signalingServerUrl.port;
 
 const peerServer = spawn("peerjs", ["--port", String(signalingServerPort)]);
 


### PR DESCRIPTION
The error handling is still pending and needs to wait for a valid dev system to be tested. So far we only removed the static configuration variable to favour the usage of the getConfiguration function