### PR TITLE
Reworked: Padding Line implementation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,12 +37,15 @@ module.exports = {
     "@typescript-eslint/restrict-template-expressions": "off",
     "@typescript-eslint/no-unused-vars": "warn",
     "@typescript-eslint/triple-slash-reference": "off",
-    "prettier/prettier": "warn",
-    "padding-line-between-statements": [
+    "padding-line-between-statements": "off",
+    "@typescript-eslint/padding-line-between-statements": [
       "warn",
-      { blankLine: "always", prev: "block-like", next: "function" },
-      { blankLine: "always", prev: "const", next: "function" },
-      { blankLine: "always", prev: "function", next: "return" },
+      {
+        blankLine: "always",
+        prev: "*",
+        next: ["interface", "type", "function"],
+      },
     ],
+    "prettier/prettier": "warn",
   },
 };

--- a/packages/frontend/src/common/context/ColorThemeContext.tsx
+++ b/packages/frontend/src/common/context/ColorThemeContext.tsx
@@ -17,6 +17,7 @@ declare module "@mui/material/styles" {
     highlightColorPrimary: string;
     highlightColorSecondary: string;
   }
+
   interface Palette {
     highlightColorPrimary: string;
     highlightColorSecondary: string;

--- a/packages/frontend/src/retro/components/TimePicker.tsx
+++ b/packages/frontend/src/retro/components/TimePicker.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { FlexBox } from "../../common/components/FlexBox";
 import { TextInput } from "../../common/components/TextInput";
 import IncrementTimerButton from "./buttons/IncrementTimerButton";
+
 interface TimePickerProps {
   minutes: string;
   seconds: string;


### PR DESCRIPTION
The original plan to integrate destructuring rules was abondaned, but I reworked the usage of the padding line rule to use the @typescript-eslint implementation. This rule now also detects typescript specific structures like interfaces.