### PR TITLE
Feature/one vote per card

### DIFF
--- a/packages/frontend/src/retro/components/buttons/ImportRetroMenuItem.tsx
+++ b/packages/frontend/src/retro/components/buttons/ImportRetroMenuItem.tsx
@@ -29,7 +29,7 @@ export function ImportRetroMenuItem() {
       participants: {},
       waitingList: {},
       isVotingEnabled: false,
-      cardVotingLimit: Number.MAX_VALUE,
+      cardVotingLimit: 1,
       timerStatus: TimerStatus.STOPPED,
       timerDuration: 0,
     };

--- a/packages/frontend/src/retro/components/buttons/ImportRetroMenuItem.tsx
+++ b/packages/frontend/src/retro/components/buttons/ImportRetroMenuItem.tsx
@@ -29,6 +29,7 @@ export function ImportRetroMenuItem() {
       participants: {},
       waitingList: {},
       isVotingEnabled: false,
+      cardVotingLimit: Number.MAX_VALUE,
       timerStatus: TimerStatus.STOPPED,
       timerDuration: 0,
     };

--- a/packages/frontend/src/retro/components/cards/UpvoteCardButton.tsx
+++ b/packages/frontend/src/retro/components/cards/UpvoteCardButton.tsx
@@ -13,19 +13,22 @@ interface UpvoteItemButtonProps extends IconButtonProps {
 }
 
 export function UpvoteCardButton({ columnIndex, card, ...props }: UpvoteItemButtonProps) {
-  const { handleUpvoteCard } = useRetroContext();
+  const { retroState, handleUpvoteCard } = useRetroContext();
+  const { cardVotingLimit } = retroState;
   const { user } = useUserContext();
   const votesLeft = useVotesLeft();
+  const votingLimitReached = (card.votes[user.id] ?? 0) >= cardVotingLimit;
+  const canUpvote = votesLeft > 0 && !votingLimitReached;
 
   function handleUpvote() {
-    if (votesLeft === 0) return;
+    if (!canUpvote) return;
     handleUpvoteCard({ columnIndex, cardIndex: card.index, userId: user.id });
   }
 
   return (
     <CardActionButton
       {...props}
-      disabled={props.disabled ?? votesLeft === 0}
+      disabled={props.disabled ? true : !canUpvote}
       onClick={handleUpvote}
       tooltipText="Upvote Card"
     >

--- a/packages/frontend/src/retro/components/cards/UpvoteCardButton.tsx
+++ b/packages/frontend/src/retro/components/cards/UpvoteCardButton.tsx
@@ -25,7 +25,7 @@ export function UpvoteCardButton({ columnIndex, card, ...props }: UpvoteItemButt
   return (
     <CardActionButton
       {...props}
-      disabled={votesLeft === 0}
+      disabled={props.disabled ?? votesLeft === 0}
       onClick={handleUpvote}
       tooltipText="Upvote Card"
     >

--- a/packages/frontend/src/retro/components/dialogs/ManageVotesDialog.tsx
+++ b/packages/frontend/src/retro/components/dialogs/ManageVotesDialog.tsx
@@ -86,7 +86,7 @@ export function ManageVotesDialog({ isOpen, close }: DialogProps) {
         </Typography>
         <FormControlLabel
           control={<Checkbox checked={isVotingPerCardLimited} onChange={handleVotingLimitChange} />}
-          label="One Vote per Card"
+          label="Maximum one vote per card"
         />
       </DialogContent>
       <DialogActions>

--- a/packages/frontend/src/retro/components/dialogs/ManageVotesDialog.tsx
+++ b/packages/frontend/src/retro/components/dialogs/ManageVotesDialog.tsx
@@ -1,11 +1,13 @@
-import React, { useState } from "react";
+import React, { ChangeEvent, useState } from "react";
 import {
   Button,
+  Checkbox,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
   FormControl,
+  FormControlLabel,
   Slider,
   Typography,
 } from "@mui/material";
@@ -17,9 +19,15 @@ import { CallToActionButton } from "../../../common/components/buttons/CallToAct
 
 export function ManageVotesDialog({ isOpen, close }: DialogProps) {
   const fullScreen = useFullscreen();
-  const { retroState, handleChangeMaxVote, handleResetVotes, handleIsVotingEnabledChanged } =
-    useRetroContext();
+  const {
+    retroState,
+    handleChangeMaxVote,
+    handleResetVotes,
+    handleIsVotingEnabledChanged,
+    handleCardVotingLimitChanged,
+  } = useRetroContext();
   const [voteCount, setVoteCount] = useState(retroState.maxVoteCount);
+  const [isVotingPerCardLimited, setIsVotingPerCardLimited] = useState(true);
 
   function handleCancel() {
     setVoteCount(retroState.maxVoteCount);
@@ -30,9 +38,14 @@ export function ManageVotesDialog({ isOpen, close }: DialogProps) {
     setVoteCount(newValue as number);
   }
 
+  function handleVotingLimitChange(event: ChangeEvent<HTMLInputElement>) {
+    setIsVotingPerCardLimited(event.target.checked);
+  }
+
   function handleStart() {
     handleChangeMaxVote(voteCount);
     handleIsVotingEnabledChanged(true);
+    handleCardVotingLimitChanged(isVotingPerCardLimited ? 1 : 999);
     close();
   }
 
@@ -71,6 +84,10 @@ export function ManageVotesDialog({ isOpen, close }: DialogProps) {
         <Typography variant="body1">
           Everybody has <strong>{voteCount}</strong> votes
         </Typography>
+        <FormControlLabel
+          control={<Checkbox checked={isVotingPerCardLimited} onChange={handleVotingLimitChange} />}
+          label="One Vote per Card"
+        />
       </DialogContent>
       <DialogActions>
         <Button onClick={handleCancel}>Cancel</Button>

--- a/packages/frontend/src/retro/components/dialogs/ManageVotesDialog.tsx
+++ b/packages/frontend/src/retro/components/dialogs/ManageVotesDialog.tsx
@@ -45,7 +45,7 @@ export function ManageVotesDialog({ isOpen, close }: DialogProps) {
   function handleStart() {
     handleChangeMaxVote(voteCount);
     handleIsVotingEnabledChanged(true);
-    handleCardVotingLimitChanged(isVotingPerCardLimited ? 1 : 999);
+    handleCardVotingLimitChanged(isVotingPerCardLimited ? 1 : Number.MAX_VALUE);
     close();
   }
 

--- a/packages/frontend/src/retro/components/dialogs/ManageVotesDialog.tsx
+++ b/packages/frontend/src/retro/components/dialogs/ManageVotesDialog.tsx
@@ -27,7 +27,9 @@ export function ManageVotesDialog({ isOpen, close }: DialogProps) {
     handleCardVotingLimitChanged,
   } = useRetroContext();
   const [voteCount, setVoteCount] = useState(retroState.maxVoteCount);
-  const [isVotingPerCardLimited, setIsVotingPerCardLimited] = useState(true);
+  const [isMaxVotesPerCardLimited, setIsMaxVotesPerCardLimited] = useState(
+    retroState.cardVotingLimit === 1
+  );
 
   function handleCancel() {
     setVoteCount(retroState.maxVoteCount);
@@ -39,13 +41,13 @@ export function ManageVotesDialog({ isOpen, close }: DialogProps) {
   }
 
   function handleVotingLimitChange(event: ChangeEvent<HTMLInputElement>) {
-    setIsVotingPerCardLimited(event.target.checked);
+    setIsMaxVotesPerCardLimited(event.target.checked);
   }
 
   function handleStart() {
     handleChangeMaxVote(voteCount);
     handleIsVotingEnabledChanged(true);
-    handleCardVotingLimitChanged(isVotingPerCardLimited ? 1 : Number.MAX_VALUE);
+    handleCardVotingLimitChanged(isMaxVotesPerCardLimited ? 1 : Number.MAX_VALUE);
     close();
   }
 
@@ -85,7 +87,9 @@ export function ManageVotesDialog({ isOpen, close }: DialogProps) {
           Everybody has <strong>{voteCount}</strong> votes
         </Typography>
         <FormControlLabel
-          control={<Checkbox checked={isVotingPerCardLimited} onChange={handleVotingLimitChange} />}
+          control={
+            <Checkbox checked={isMaxVotesPerCardLimited} onChange={handleVotingLimitChange} />
+          }
           label="Maximum one vote per card"
         />
       </DialogContent>

--- a/packages/frontend/src/retro/context/RetroContext.tsx
+++ b/packages/frontend/src/retro/context/RetroContext.tsx
@@ -232,7 +232,6 @@ export function RetroContextProvider(props: RetroContextProviderProps) {
   }
 
   function handleCardVotingLimitChanged(limit: number) {
-    console.log("Voting changed to ", limit);
     dispatchAndBroadcast({ type: "CARD_VOTING_LIMIT_CHANGED", limit });
   }
 

--- a/packages/frontend/src/retro/context/RetroContext.tsx
+++ b/packages/frontend/src/retro/context/RetroContext.tsx
@@ -48,6 +48,7 @@ const initialState: RetroState = {
   participants: {},
   waitingList: {},
   isVotingEnabled: false,
+  cardVotingLimit: 1,
   timerStatus: TimerStatus.STOPPED,
   timerDuration: 0,
 };
@@ -82,6 +83,7 @@ export interface RetroContextValues {
   handleAcceptJoinUser: (userId: string) => void;
   handleAddToWaitingList: (payload: AddToWaitingListAction["payload"]) => void;
   handleIsVotingEnabledChanged: (isEnabled: boolean) => void;
+  handleCardVotingLimitChanged: (limit: number) => void;
   handleStartTimer: (duration: number) => void;
   handlePauseTimer: () => void;
   handleChangeTimer: (duration: number) => void;
@@ -229,6 +231,11 @@ export function RetroContextProvider(props: RetroContextProviderProps) {
     dispatchAndBroadcast({ type: "IS_VOTING_ENABLED_CHANGED", isEnabled });
   }
 
+  function handleCardVotingLimitChanged(limit: number) {
+    console.log("Voting changed to ", limit);
+    dispatchAndBroadcast({ type: "CARD_VOTING_LIMIT_CHANGED", limit });
+  }
+
   function handleStartTimer(duration: StartTimerAction["duration"]) {
     dispatchAndBroadcast({ type: "START_TIMER", duration });
   }
@@ -283,6 +290,7 @@ export function RetroContextProvider(props: RetroContextProviderProps) {
     handleAcceptJoinUser: acceptJoinUser,
     handleAddToWaitingList,
     handleIsVotingEnabledChanged,
+    handleCardVotingLimitChanged,
     handleStartTimer,
     handlePauseTimer,
     handleStopTimer,

--- a/packages/frontend/src/retro/reducers/retroReducer.ts
+++ b/packages/frontend/src/retro/reducers/retroReducer.ts
@@ -224,6 +224,9 @@ export const retroReducer = (state: RetroState, action: RetroAction): RetroState
     case "IS_VOTING_ENABLED_CHANGED": {
       return { ...state, isVotingEnabled: action.isEnabled };
     }
+    case "CARD_VOTING_LIMIT_CHANGED": {
+      return { ...state, cardVotingLimit: action.limit };
+    }
     case "START_TIMER": {
       return {
         ...state,

--- a/packages/frontend/src/retro/types/retroActions.ts
+++ b/packages/frontend/src/retro/types/retroActions.ts
@@ -94,6 +94,10 @@ export interface IsVotingEnabledChangedAction extends BaseAction {
   type: "IS_VOTING_ENABLED_CHANGED";
   isEnabled: boolean;
 }
+export interface CardVotingLimitChangedAction extends BaseAction {
+  type: "CARD_VOTING_LIMIT_CHANGED";
+  limit: number;
+}
 
 export interface StartTimerAction extends BaseAction {
   type: "START_TIMER";
@@ -134,6 +138,7 @@ export type RetroAction =
   | ChangeRetroFormatAction
   | SortCardsByVotesDescendingAction
   | IsVotingEnabledChangedAction
+  | CardVotingLimitChangedAction
   | StartTimerAction
   | PauseTimerAction
   | StopTimerAction

--- a/packages/frontend/src/retro/types/retroTypes.ts
+++ b/packages/frontend/src/retro/types/retroTypes.ts
@@ -31,6 +31,7 @@ export interface RetroState {
   participants: UserByUserId;
   waitingList: UserByUserId;
   isVotingEnabled: boolean;
+  cardVotingLimit: number;
   timerStatus: TimerStatus;
   timerDuration: number;
 }


### PR DESCRIPTION
The card voting on the retro board can now be limited to one vote per user per card. The option is active by default an accessible in the voting dialog via a checkbox. The implementation allows for future expansion as the limit is implemented as a number. 

Issue: #193 

## Acceptance Criteria
- [x] When starting the voting, the user can check a box Maximum one vote per card
- [x] The box is checked by default
- [x] A card can only be voted once per user if this option is enabled
- [x] User can't upvote twice, but downvote again to remove the current vote on that card
