### PR TITLE
Fix - Voting starts at Zero instead of One

### DIFF
--- a/packages/frontend/src/retro/context/RetroContext.tsx
+++ b/packages/frontend/src/retro/context/RetroContext.tsx
@@ -44,7 +44,7 @@ const initialState: RetroState = {
   format: "",
   columns: [],
   isBlurred: false,
-  maxVoteCount: 0,
+  maxVoteCount: 1,
   participants: {},
   waitingList: {},
   isVotingEnabled: false,


### PR DESCRIPTION
The voting option started at a total vote count of zero, which makes no sense for the feature. It should instead start with one.

#206 