### PR TITLE
Save Username in Local Storage only at Permission

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,7 +43,7 @@ module.exports = {
       {
         blankLine: "always",
         prev: "*",
-        next: ["interface", "type", "function"],
+        next: ["interface", "type", "function", "export"],
       },
     ],
     "prettier/prettier": "warn",

--- a/packages/frontend/src/common/components/TextInput.tsx
+++ b/packages/frontend/src/common/components/TextInput.tsx
@@ -3,7 +3,7 @@ import { TextField } from "@mui/material";
 import { StandardTextFieldProps } from "@mui/material/TextField/TextField";
 import { ErrorHelperText } from "./ErrorHelperText";
 
-interface TextInputProps extends StandardTextFieldProps {
+export interface TextInputProps extends StandardTextFieldProps {
   onSubmit: () => void;
   errorHelperText?: string;
 }

--- a/packages/frontend/src/common/dialogs/JoinSessionDialog.tsx
+++ b/packages/frontend/src/common/dialogs/JoinSessionDialog.tsx
@@ -94,15 +94,15 @@ export function JoinSessionDialog({ onAddToWaitingList }: JoinSessionDialogProps
       <DialogContent>
         <UserNameInputField
           userName={name}
-          label="Please provide your name for this session"
+          textFieldId="user-name"
           onSubmit={handleSubmit}
           onChange={handleChange}
           isError={isError}
           isStorageAllowed={isStorageAllowed}
-          storagePermissionLabel="Allow local username storage"
           onStorageAllowanceChange={(event) => {
             handleAllowanceChange(event.target.checked);
           }}
+          autoFocus
         />
       </DialogContent>
       <DialogActions>

--- a/packages/frontend/src/common/dialogs/JoinSessionDialog.tsx
+++ b/packages/frontend/src/common/dialogs/JoinSessionDialog.tsx
@@ -17,13 +17,12 @@ import { generateId } from "../utils/generateId";
 import { useBackendAdapter } from "../adapter/backendAdapter";
 import { useNamespace } from "../hooks/useNamespace";
 import { useErrorContext } from "../context/ErrorContext";
-import { LocalStorage } from "../utils/localStorage";
-import { useLocalStorage } from "../hooks/useLocalStorage";
 import { CallToActionButton } from "../components/buttons/CallToActionButton";
 import { useDialog } from "../hooks/useDialog";
 import { useRedirect } from "../hooks/useRedirect";
 import { useRoomIdFromPath } from "../hooks/useRoomIdFromPath";
 import UserNameInputField from "../../retro/components/dialogs/UsernameInputField";
+import useLocalStorageName from "../../retro/hooks/useLocalStorageName";
 
 interface JoinSessionDialogProps {
   onAddToWaitingList: ({ userId, userName }: { userId: string; userName: string }) => void;
@@ -39,6 +38,9 @@ export function JoinSessionDialog({ onAddToWaitingList }: JoinSessionDialogProps
     handleChange,
     isValid,
   } = useValidatedTextInput({ minLength: 1, maxLength: 40 });
+  const { isStorageAllowed, saveNameLocally, handleAllowanceChange } = useLocalStorageName({
+    setName,
+  });
   const { redirectBackToHome, redirectToRoom } = useRedirect();
   const { setError } = useErrorContext();
   const { setRoomId } = useRoomContext();
@@ -48,10 +50,6 @@ export function JoinSessionDialog({ onAddToWaitingList }: JoinSessionDialogProps
   const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
   const namespace = useNamespace();
   const { roomIdExists } = useBackendAdapter();
-
-  useLocalStorage(() => {
-    setName(LocalStorage.getUserName());
-  });
 
   function handleClose() {
     setName("");
@@ -80,7 +78,7 @@ export function JoinSessionDialog({ onAddToWaitingList }: JoinSessionDialogProps
     };
     setRoomId(roomId);
     setUser(newUser);
-    LocalStorage.setUserName(name);
+    saveNameLocally(name);
     onAddToWaitingList({ userId: newUser.id, userName: name });
     redirectToRoom(roomId);
     handleClose();
@@ -102,9 +100,11 @@ export function JoinSessionDialog({ onAddToWaitingList }: JoinSessionDialogProps
           onSubmit={handleSubmit}
           onChange={handleChange}
           isError={isError}
-          isStorageAllowed={true}
+          isStorageAllowed={isStorageAllowed}
           storagePermissionLabel="Allow local username storage"
-          onStorageAllowanceChange={handleStorageAllowanceChange}
+          onStorageAllowanceChange={(event) => {
+            handleAllowanceChange(event.target.checked);
+          }}
         />
       </DialogContent>
       <DialogActions>

--- a/packages/frontend/src/common/dialogs/JoinSessionDialog.tsx
+++ b/packages/frontend/src/common/dialogs/JoinSessionDialog.tsx
@@ -57,8 +57,6 @@ export function JoinSessionDialog({ onAddToWaitingList }: JoinSessionDialogProps
     setIsError(false);
   }
 
-  function handleStorageAllowanceChange() {}
-
   async function handleSubmit() {
     const roomExists = await roomIdExists({ roomId, namespace });
     if (!roomExists || !roomId) {

--- a/packages/frontend/src/common/dialogs/JoinSessionDialog.tsx
+++ b/packages/frontend/src/common/dialogs/JoinSessionDialog.tsx
@@ -3,7 +3,6 @@ import {
   Dialog,
   DialogActions,
   DialogContent,
-  DialogContentText,
   DialogTitle,
   useMediaQuery,
   useTheme,
@@ -17,7 +16,6 @@ import { generateId } from "../utils/generateId";
 
 import { useBackendAdapter } from "../adapter/backendAdapter";
 import { useNamespace } from "../hooks/useNamespace";
-import { TextInput } from "../components/TextInput";
 import { useErrorContext } from "../context/ErrorContext";
 import { LocalStorage } from "../utils/localStorage";
 import { useLocalStorage } from "../hooks/useLocalStorage";
@@ -25,6 +23,7 @@ import { CallToActionButton } from "../components/buttons/CallToActionButton";
 import { useDialog } from "../hooks/useDialog";
 import { useRedirect } from "../hooks/useRedirect";
 import { useRoomIdFromPath } from "../hooks/useRoomIdFromPath";
+import UserNameInputField from "../../retro/components/dialogs/UsernameInputField";
 
 interface JoinSessionDialogProps {
   onAddToWaitingList: ({ userId, userName }: { userId: string; userName: string }) => void;
@@ -59,6 +58,8 @@ export function JoinSessionDialog({ onAddToWaitingList }: JoinSessionDialogProps
     closeDialog();
     setIsError(false);
   }
+
+  function handleStorageAllowanceChange() {}
 
   async function handleSubmit() {
     const roomExists = await roomIdExists({ roomId, namespace });
@@ -95,18 +96,15 @@ export function JoinSessionDialog({ onAddToWaitingList }: JoinSessionDialogProps
     >
       <DialogTitle id="join-poker-dialog-title">Join Session</DialogTitle>
       <DialogContent>
-        <DialogContentText>Please provide your name for this session</DialogContentText>
-        <TextInput
+        <UserNameInputField
+          userName={name}
+          label="Please provide your name for this session"
           onSubmit={handleSubmit}
-          required
-          autoFocus
-          fullWidth
-          value={name}
           onChange={handleChange}
-          error={isError}
-          id="user-name"
-          label="Name"
-          type="text"
+          isError={isError}
+          isStorageAllowed={true}
+          storagePermissionLabel="Allow local username storage"
+          onStorageAllowanceChange={handleStorageAllowanceChange}
         />
       </DialogContent>
       <DialogActions>

--- a/packages/frontend/src/common/dialogs/JoinSessionDialog.tsx
+++ b/packages/frontend/src/common/dialogs/JoinSessionDialog.tsx
@@ -38,7 +38,7 @@ export function JoinSessionDialog({ onAddToWaitingList }: JoinSessionDialogProps
     handleChange,
     isValid,
   } = useValidatedTextInput({ minLength: 1, maxLength: 40 });
-  const { isStorageAllowed, saveNameLocally, handleAllowanceChange } = useLocalStorageName({
+  const { isStorageAllowed, trySavingNameLocally, handleAllowanceChange } = useLocalStorageName({
     setName,
   });
   const { redirectBackToHome, redirectToRoom } = useRedirect();
@@ -76,7 +76,7 @@ export function JoinSessionDialog({ onAddToWaitingList }: JoinSessionDialogProps
     };
     setRoomId(roomId);
     setUser(newUser);
-    saveNameLocally(name);
+    trySavingNameLocally(name);
     onAddToWaitingList({ userId: newUser.id, userName: name });
     redirectToRoom(roomId);
     handleClose();

--- a/packages/frontend/src/common/dialogs/JoinSessionDialog.tsx
+++ b/packages/frontend/src/common/dialogs/JoinSessionDialog.tsx
@@ -94,10 +94,10 @@ export function JoinSessionDialog({ onAddToWaitingList }: JoinSessionDialogProps
       <DialogContent>
         <UserNameInputField
           userName={name}
-          textFieldId="user-name"
+          id="user-name"
           onSubmit={handleSubmit}
           onChange={handleChange}
-          isError={isError}
+          error={isError}
           isStorageAllowed={isStorageAllowed}
           onStorageAllowanceChange={(event) => {
             handleAllowanceChange(event.target.checked);

--- a/packages/frontend/src/common/dialogs/Participant.tsx
+++ b/packages/frontend/src/common/dialogs/Participant.tsx
@@ -14,6 +14,7 @@ interface ParticipantProps {
   handleKickUser: (userId: string) => void;
   handleTransferModeratorRole: (userId: string) => void;
 }
+
 export function Participant({
   participant,
   handleKickUser,

--- a/packages/frontend/src/common/dialogs/WaitingUser.tsx
+++ b/packages/frontend/src/common/dialogs/WaitingUser.tsx
@@ -12,6 +12,7 @@ interface WaitingUserProps {
   handleRejectJoinUser: (userId: string) => void;
   handleAcceptJoinUser: (userId: string) => void;
 }
+
 export function WaitingUser({
   waitingUser,
   handleRejectJoinUser,

--- a/packages/frontend/src/common/utils/localStorage.ts
+++ b/packages/frontend/src/common/utils/localStorage.ts
@@ -1,4 +1,5 @@
 const userNameKey = "userName";
+const usernameStorePermissionKey = "userAllowsNameStorage";
 
 function setUserName(userName: string) {
   localStorage.setItem(userNameKey, userName);
@@ -8,4 +9,22 @@ function getUserName() {
   return localStorage.getItem(userNameKey) ?? "";
 }
 
-export const LocalStorage = { setUserName, getUserName };
+function removeUserName() {
+  localStorage.removeItem(userNameKey);
+}
+
+function setNameStorePermission(permission: boolean) {
+  localStorage.setItem(usernameStorePermissionKey, String(permission));
+}
+
+function getNameStorePermission(): boolean {
+  const value = localStorage.getItem(usernameStorePermissionKey);
+  return value === "true";
+}
+export const LocalStorage = {
+  setUserName,
+  getUserName,
+  removeUserName,
+  setNameStorePermission,
+  getNameStorePermission,
+};

--- a/packages/frontend/src/common/utils/localStorage.ts
+++ b/packages/frontend/src/common/utils/localStorage.ts
@@ -21,6 +21,7 @@ function getNameStorePermission(): boolean {
   const value = localStorage.getItem(usernameStorePermissionKey);
   return value === "true";
 }
+
 export const LocalStorage = {
   setUserName,
   getUserName,

--- a/packages/frontend/src/poker/context/PokerContext.tsx
+++ b/packages/frontend/src/poker/context/PokerContext.tsx
@@ -57,6 +57,7 @@ const initialState: PokerState = {
 };
 
 export const PokerContext = React.createContext<PokerContextValues>(undefined!);
+
 export function PokerContextProvider(props: PokerContextProviderProps) {
   const [state, dispatch] = useReducer(pokerReducer, initialState);
   const { user } = useUserContext();

--- a/packages/frontend/src/retro/components/CircularProgressWithLabel.tsx
+++ b/packages/frontend/src/retro/components/CircularProgressWithLabel.tsx
@@ -10,6 +10,7 @@ interface CircularProgressWithLabelProps {
   maxValue: number;
   currentValue: number;
 }
+
 export function CircularProgressWithLabel({
   maxValue,
   currentValue,

--- a/packages/frontend/src/retro/components/TimePicker.tsx
+++ b/packages/frontend/src/retro/components/TimePicker.tsx
@@ -14,6 +14,7 @@ interface TimePickerProps {
   onSubmit: () => void;
   onTimerIncrement: (increment: number) => void;
 }
+
 export function TimePicker({
   minutes,
   seconds,

--- a/packages/frontend/src/retro/components/buttons/IncrementTimerButton.tsx
+++ b/packages/frontend/src/retro/components/buttons/IncrementTimerButton.tsx
@@ -5,6 +5,7 @@ interface IncrementTimerButtonProps {
   onTimerIncrement: (amount: number) => void;
   minutesToIncrement: number;
 }
+
 export default function IncrementTimerButton({
   onTimerIncrement,
   minutesToIncrement,

--- a/packages/frontend/src/retro/components/dialogs/CreateRetroSessionDialog.tsx
+++ b/packages/frontend/src/retro/components/dialogs/CreateRetroSessionDialog.tsx
@@ -109,6 +109,7 @@ export function CreateRetroSessionDialog() {
             onStorageAllowanceChange={(event) => {
               handleAllowanceChange(event.target.checked);
             }}
+            autoFocus
           />
         </Box>
         <Box>
@@ -120,7 +121,6 @@ export function CreateRetroSessionDialog() {
             error={isTitleError}
             id="retro-name"
             label="Retro Name"
-            autoFocus
           />
         </Box>
         <Box>

--- a/packages/frontend/src/retro/components/dialogs/CreateRetroSessionDialog.tsx
+++ b/packages/frontend/src/retro/components/dialogs/CreateRetroSessionDialog.tsx
@@ -20,12 +20,11 @@ import { generateId } from "../../../common/utils/generateId";
 import { TextInput } from "../../../common/components/TextInput";
 import { useValidatedTextInput } from "../../../common/hooks/useValidatedTextInput";
 import { useRoomContext } from "../../../common/context/RoomContext";
-import { LocalStorage } from "../../../common/utils/localStorage";
-import { useLocalStorage } from "../../../common/hooks/useLocalStorage";
 import { CallToActionButton } from "../../../common/components/buttons/CallToActionButton";
 import { useDialog } from "../../../common/hooks/useDialog";
 import { useRedirect } from "../../../common/hooks/useRedirect";
 import UserNameInputField from "./UsernameInputField";
+import useLocalStorageName from "../../hooks/useLocalStorageName";
 
 export function CreateRetroSessionDialog() {
   const { isOpen, closeDialog } = useDialog(true);
@@ -51,15 +50,12 @@ export function CreateRetroSessionDialog() {
   const { retroState, handleChangeRetroFormat, handleSetRetroState, handleJoinSession } =
     useRetroContext();
   const { user, setUser } = useUserContext();
-  const [isNameStorageAllowed, setIsNameStorageAllowed] = useState(false);
+  const { isStorageAllowed, saveNameLocally, handleAllowanceChange } = useLocalStorageName({
+    setName,
+  });
   const { setRoomId } = useRoomContext();
   const theme = useTheme();
   const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
-
-  useLocalStorage(() => {
-    setName(LocalStorage.getUserName());
-    setIsNameStorageAllowed(LocalStorage.getNameStorePermission());
-  });
 
   function handleClose() {
     setName("");
@@ -85,23 +81,11 @@ export function CreateRetroSessionDialog() {
     setRoomId(roomId);
     handleSetRetroState({ ...retroState, title });
     setUser(newUser);
-    if (isNameStorageAllowed) {
-      LocalStorage.setUserName(name);
-    }
+    saveNameLocally(name);
     handleJoinSession(newUser);
     handleChangeRetroFormat(format);
     redirectToRoom(roomId);
     handleClose();
-  }
-
-  function handleStorageAllowanceChange(event: React.ChangeEvent<HTMLInputElement>) {
-    if (event.target.checked) {
-      LocalStorage.setUserName(name);
-    } else {
-      LocalStorage.removeUserName();
-    }
-    LocalStorage.setNameStorePermission(event.target.checked);
-    setIsNameStorageAllowed(event.target.checked);
   }
 
   return (
@@ -121,9 +105,11 @@ export function CreateRetroSessionDialog() {
             onSubmit={handleSubmit}
             onChange={handleNameChange}
             isError={isNameError}
-            isStorageAllowed={isNameStorageAllowed}
+            isStorageAllowed={isStorageAllowed}
             storagePermissionLabel="Allow local username storage"
-            onStorageAllowanceChange={handleStorageAllowanceChange}
+            onStorageAllowanceChange={(event) => {
+              handleAllowanceChange(event.target.checked);
+            }}
           />
         </Box>
         <Box>

--- a/packages/frontend/src/retro/components/dialogs/CreateRetroSessionDialog.tsx
+++ b/packages/frontend/src/retro/components/dialogs/CreateRetroSessionDialog.tsx
@@ -50,7 +50,7 @@ export function CreateRetroSessionDialog() {
   const { retroState, handleChangeRetroFormat, handleSetRetroState, handleJoinSession } =
     useRetroContext();
   const { user, setUser } = useUserContext();
-  const { isStorageAllowed, saveNameLocally, handleAllowanceChange } = useLocalStorageName({
+  const { isStorageAllowed, trySavingNameLocally, handleAllowanceChange } = useLocalStorageName({
     setName,
   });
   const { setRoomId } = useRoomContext();
@@ -81,7 +81,7 @@ export function CreateRetroSessionDialog() {
     setRoomId(roomId);
     handleSetRetroState({ ...retroState, title });
     setUser(newUser);
-    saveNameLocally(name);
+    trySavingNameLocally(name);
     handleJoinSession(newUser);
     handleChangeRetroFormat(format);
     redirectToRoom(roomId);

--- a/packages/frontend/src/retro/components/dialogs/CreateRetroSessionDialog.tsx
+++ b/packages/frontend/src/retro/components/dialogs/CreateRetroSessionDialog.tsx
@@ -101,10 +101,10 @@ export function CreateRetroSessionDialog() {
         <Box>
           <UserNameInputField
             userName={name}
-            textFieldId="user-name"
+            id="user-name"
             onSubmit={handleSubmit}
             onChange={handleNameChange}
-            isError={isNameError}
+            error={isNameError}
             isStorageAllowed={isStorageAllowed}
             onStorageAllowanceChange={(event) => {
               handleAllowanceChange(event.target.checked);

--- a/packages/frontend/src/retro/components/dialogs/CreateRetroSessionDialog.tsx
+++ b/packages/frontend/src/retro/components/dialogs/CreateRetroSessionDialog.tsx
@@ -101,12 +101,11 @@ export function CreateRetroSessionDialog() {
         <Box>
           <UserNameInputField
             userName={name}
-            label="Please enter your name"
+            textFieldId="user-name"
             onSubmit={handleSubmit}
             onChange={handleNameChange}
             isError={isNameError}
             isStorageAllowed={isStorageAllowed}
-            storagePermissionLabel="Allow local username storage"
             onStorageAllowanceChange={(event) => {
               handleAllowanceChange(event.target.checked);
             }}
@@ -121,6 +120,7 @@ export function CreateRetroSessionDialog() {
             error={isTitleError}
             id="retro-name"
             label="Retro Name"
+            autoFocus
           />
         </Box>
         <Box>

--- a/packages/frontend/src/retro/components/dialogs/TimerDialog.tsx
+++ b/packages/frontend/src/retro/components/dialogs/TimerDialog.tsx
@@ -12,6 +12,7 @@ interface TimerDialogProps extends DialogProps {
   remainingMinutes: number;
   remainingSeconds: number;
 }
+
 export function TimerDialog({
   isOpen,
   close,

--- a/packages/frontend/src/retro/components/dialogs/UsernameInputField.tsx
+++ b/packages/frontend/src/retro/components/dialogs/UsernameInputField.tsx
@@ -12,6 +12,7 @@ interface UserNameInputFieldProps {
   isStorageAllowed: boolean;
   onStorageAllowanceChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }
+
 export default function UserNameInputField({
   userName,
   label,

--- a/packages/frontend/src/retro/components/dialogs/UsernameInputField.tsx
+++ b/packages/frontend/src/retro/components/dialogs/UsernameInputField.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, DialogContentText, FormControlLabel } from "@mui/material";
+import { Checkbox, DialogContentText, FormControlLabel, Tooltip } from "@mui/material";
 import { TextInput } from "../../../common/components/TextInput";
 import React from "react";
 
@@ -34,10 +34,12 @@ export default function UserNameInputField({
         label="Username"
         autoFocus
       />
-      <FormControlLabel
-        control={<Checkbox checked={isStorageAllowed} onChange={onStorageAllowanceChange} />}
-        label={storagePermissionLabel}
-      />
+      <Tooltip title="If checked the user name is saved in your local storage for future sessions. Your data stays always local and is not transmitted to any external service">
+        <FormControlLabel
+          control={<Checkbox checked={isStorageAllowed} onChange={onStorageAllowanceChange} />}
+          label={storagePermissionLabel}
+        ></FormControlLabel>
+      </Tooltip>
     </>
   );
 }

--- a/packages/frontend/src/retro/components/dialogs/UsernameInputField.tsx
+++ b/packages/frontend/src/retro/components/dialogs/UsernameInputField.tsx
@@ -1,0 +1,43 @@
+import { Checkbox, DialogContentText, FormControlLabel } from "@mui/material";
+import { TextInput } from "../../../common/components/TextInput";
+import React from "react";
+
+interface UserNameInputFieldProps {
+  userName: string;
+  label: string;
+  onSubmit: () => void;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  isError: boolean;
+  storagePermissionLabel: string;
+  isStorageAllowed: boolean;
+  onStorageAllowanceChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+}
+export default function UserNameInputField({
+  userName,
+  label,
+  onSubmit,
+  onChange,
+  isError,
+  isStorageAllowed,
+  storagePermissionLabel,
+  onStorageAllowanceChange,
+}: UserNameInputFieldProps) {
+  return (
+    <>
+      <DialogContentText>{label}</DialogContentText>
+      <TextInput
+        value={userName}
+        onSubmit={onSubmit}
+        onChange={onChange}
+        error={isError}
+        id="user-name"
+        label="Username"
+        autoFocus
+      />
+      <FormControlLabel
+        control={<Checkbox checked={isStorageAllowed} onChange={onStorageAllowanceChange} />}
+        label={storagePermissionLabel}
+      />
+    </>
+  );
+}

--- a/packages/frontend/src/retro/components/dialogs/UsernameInputField.tsx
+++ b/packages/frontend/src/retro/components/dialogs/UsernameInputField.tsx
@@ -1,6 +1,6 @@
-import { Checkbox, DialogContentText, FormControlLabel, IconButton, Tooltip } from "@mui/material";
-import { TextInput, TextInputProps } from "../../../common/components/TextInput";
+import { Checkbox, DialogContentText, FormControlLabel, Stack, Tooltip } from "@mui/material";
 import InfoIcon from "@mui/icons-material/Info";
+import { TextInput, TextInputProps } from "../../../common/components/TextInput";
 import React from "react";
 
 interface UserNameInputFieldProps extends TextInputProps {
@@ -17,7 +17,6 @@ export default function UserNameInputField({
   label = "Please enter your name",
   storagePermissionLabel = "Remember me",
   textFieldLabel = "Username",
-  id,
   onSubmit,
   onChange,
   error,
@@ -36,20 +35,19 @@ export default function UserNameInputField({
         label={textFieldLabel}
         {...props}
       />
-
-      <FormControlLabel
-        control={<Checkbox checked={isStorageAllowed} onChange={onStorageAllowanceChange} />}
-        label={storagePermissionLabel}
-        sx={{ marginRight: 0 }}
-      />
-      <Tooltip
-        arrow
-        title="If checked, the username will be persisted in the local storage of your browser for future sessions. Unchecking the box will remove this information from your browser again. Your username will only be shared while collaborating and will not be persisted on any server or transmitted to any external service."
-      >
-        <IconButton>
+      <Stack direction="row" alignItems="center" gap={1}>
+        <FormControlLabel
+          control={<Checkbox checked={isStorageAllowed} onChange={onStorageAllowanceChange} />}
+          label={storagePermissionLabel}
+          sx={{ marginRight: 0 }}
+        />
+        <Tooltip
+          arrow
+          title="If checked, the username will be persisted in the local storage of your browser for future sessions. Unchecking the box will remove this information from your browser again. Your username will only be shared while collaborating and will not be persisted on any server or transmitted to any external service."
+        >
           <InfoIcon />
-        </IconButton>
-      </Tooltip>
+        </Tooltip>
+      </Stack>
     </>
   );
 }

--- a/packages/frontend/src/retro/components/dialogs/UsernameInputField.tsx
+++ b/packages/frontend/src/retro/components/dialogs/UsernameInputField.tsx
@@ -1,27 +1,33 @@
-import { Checkbox, DialogContentText, FormControlLabel, Tooltip } from "@mui/material";
-import { TextInput } from "../../../common/components/TextInput";
+import { Checkbox, DialogContentText, FormControlLabel, IconButton, Tooltip } from "@mui/material";
+import { TextInput, TextInputProps } from "../../../common/components/TextInput";
+import InfoIcon from "@mui/icons-material/Info";
 import React from "react";
 
-interface UserNameInputFieldProps {
+interface UserNameInputFieldProps extends TextInputProps {
   userName: string;
-  label: string;
+  label?: string;
+  textFieldLabel?: string;
+  storagePermissionLabel?: string;
+  textFieldId: string;
   onSubmit: () => void;
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   isError: boolean;
-  storagePermissionLabel: string;
   isStorageAllowed: boolean;
   onStorageAllowanceChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 export default function UserNameInputField({
   userName,
-  label,
+  label = "Please enter your name",
+  storagePermissionLabel = "Remember me",
+  textFieldLabel = "Username",
+  textFieldId = "user-name",
   onSubmit,
   onChange,
   isError,
   isStorageAllowed,
-  storagePermissionLabel,
   onStorageAllowanceChange,
+  ...props
 }: UserNameInputFieldProps) {
   return (
     <>
@@ -31,15 +37,20 @@ export default function UserNameInputField({
         onSubmit={onSubmit}
         onChange={onChange}
         error={isError}
-        id="user-name"
-        label="Username"
-        autoFocus
+        id={textFieldId}
+        label={textFieldLabel}
+        {...props}
       />
-      <Tooltip title="If checked the user name is saved in your local storage for future sessions. Your data stays always local and is not transmitted to any external service">
-        <FormControlLabel
-          control={<Checkbox checked={isStorageAllowed} onChange={onStorageAllowanceChange} />}
-          label={storagePermissionLabel}
-        ></FormControlLabel>
+
+      <FormControlLabel
+        control={<Checkbox checked={isStorageAllowed} onChange={onStorageAllowanceChange} />}
+        label={storagePermissionLabel}
+        sx={{ marginRight: 0 }}
+      />
+      <Tooltip title="If checked, the username will be persisted in the local storage of your browser for future sessions. Unchecking the box will remove this information from your browser again. Your username will only be shared while collaborating and will not be persisted on any server or transmitted to any external service.">
+        <IconButton>
+          <InfoIcon />
+        </IconButton>
       </Tooltip>
     </>
   );

--- a/packages/frontend/src/retro/components/dialogs/UsernameInputField.tsx
+++ b/packages/frontend/src/retro/components/dialogs/UsernameInputField.tsx
@@ -8,10 +8,6 @@ interface UserNameInputFieldProps extends TextInputProps {
   label?: string;
   textFieldLabel?: string;
   storagePermissionLabel?: string;
-  textFieldId: string;
-  onSubmit: () => void;
-  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  isError: boolean;
   isStorageAllowed: boolean;
   onStorageAllowanceChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }
@@ -21,10 +17,10 @@ export default function UserNameInputField({
   label = "Please enter your name",
   storagePermissionLabel = "Remember me",
   textFieldLabel = "Username",
-  textFieldId = "user-name",
+  id,
   onSubmit,
   onChange,
-  isError,
+  error,
   isStorageAllowed,
   onStorageAllowanceChange,
   ...props
@@ -36,8 +32,7 @@ export default function UserNameInputField({
         value={userName}
         onSubmit={onSubmit}
         onChange={onChange}
-        error={isError}
-        id={textFieldId}
+        error={error}
         label={textFieldLabel}
         {...props}
       />
@@ -47,7 +42,10 @@ export default function UserNameInputField({
         label={storagePermissionLabel}
         sx={{ marginRight: 0 }}
       />
-      <Tooltip title="If checked, the username will be persisted in the local storage of your browser for future sessions. Unchecking the box will remove this information from your browser again. Your username will only be shared while collaborating and will not be persisted on any server or transmitted to any external service.">
+      <Tooltip
+        arrow
+        title="If checked, the username will be persisted in the local storage of your browser for future sessions. Unchecking the box will remove this information from your browser again. Your username will only be shared while collaborating and will not be persisted on any server or transmitted to any external service."
+      >
         <IconButton>
           <InfoIcon />
         </IconButton>

--- a/packages/frontend/src/retro/hooks/useLocalStorageName.ts
+++ b/packages/frontend/src/retro/hooks/useLocalStorageName.ts
@@ -1,6 +1,6 @@
-import { useLocalStorage } from "../../common/hooks/useLocalStorage";
 import { useState } from "react";
 import { LocalStorage } from "../../common/utils/localStorage";
+import { useLocalStorage } from "../../common/hooks/useLocalStorage";
 
 interface useLocalStorageNameProps {
   setName: (name: string) => void;
@@ -13,7 +13,7 @@ export default function useLocalStorageName({ setName }: useLocalStorageNameProp
     setIsStorageAllowed(LocalStorage.getNameStorePermission());
   });
 
-  function saveNameLocally(name: string) {
+  function trySavingNameLocally(name: string) {
     if (isStorageAllowed) {
       LocalStorage.setUserName(name);
     }
@@ -27,5 +27,5 @@ export default function useLocalStorageName({ setName }: useLocalStorageNameProp
     setIsStorageAllowed(isAllowed);
   }
 
-  return { isStorageAllowed, saveNameLocally, handleAllowanceChange };
+  return { isStorageAllowed, trySavingNameLocally, handleAllowanceChange };
 }

--- a/packages/frontend/src/retro/hooks/useLocalStorageName.ts
+++ b/packages/frontend/src/retro/hooks/useLocalStorageName.ts
@@ -5,6 +5,7 @@ import { useLocalStorage } from "../../common/hooks/useLocalStorage";
 interface useLocalStorageNameProps {
   setName: (name: string) => void;
 }
+
 export default function useLocalStorageName({ setName }: useLocalStorageNameProps) {
   const [isStorageAllowed, setIsStorageAllowed] = useState(false);
 

--- a/packages/frontend/src/retro/hooks/useLocalStorageName.ts
+++ b/packages/frontend/src/retro/hooks/useLocalStorageName.ts
@@ -1,0 +1,31 @@
+import { useLocalStorage } from "../../common/hooks/useLocalStorage";
+import { useState } from "react";
+import { LocalStorage } from "../../common/utils/localStorage";
+
+interface useLocalStorageNameProps {
+  setName: (name: string) => void;
+}
+export default function useLocalStorageName({ setName }: useLocalStorageNameProps) {
+  const [isStorageAllowed, setIsStorageAllowed] = useState(false);
+
+  useLocalStorage(() => {
+    setName(LocalStorage.getUserName());
+    setIsStorageAllowed(LocalStorage.getNameStorePermission());
+  });
+
+  function saveNameLocally(name: string) {
+    if (isStorageAllowed) {
+      LocalStorage.setUserName(name);
+    }
+  }
+
+  function handleAllowanceChange(isAllowed: boolean) {
+    if (!isAllowed) {
+      LocalStorage.removeUserName();
+    }
+    LocalStorage.setNameStorePermission(isAllowed);
+    setIsStorageAllowed(isAllowed);
+  }
+
+  return { isStorageAllowed, saveNameLocally, handleAllowanceChange };
+}

--- a/packages/frontend/src/retro/hooks/useTimedEffect.ts
+++ b/packages/frontend/src/retro/hooks/useTimedEffect.ts
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 interface useTimedEffectProps {
   effectLength: number;
 }
+
 export default function useTimedEffect({ effectLength }: useTimedEffectProps) {
   const [isEffectActive, setIsEffectActive] = useState(false);
 

--- a/packages/frontend/src/retro/types/retroActions.ts
+++ b/packages/frontend/src/retro/types/retroActions.ts
@@ -94,6 +94,7 @@ export interface IsVotingEnabledChangedAction extends BaseAction {
   type: "IS_VOTING_ENABLED_CHANGED";
   isEnabled: boolean;
 }
+
 export interface CardVotingLimitChangedAction extends BaseAction {
   type: "CARD_VOTING_LIMIT_CHANGED";
   limit: number;

--- a/packages/frontend/src/retro/types/retroTypes.ts
+++ b/packages/frontend/src/retro/types/retroTypes.ts
@@ -16,11 +16,13 @@ export interface RetroColumn {
   cards: RetroCard[];
   isBlurred: boolean;
 }
+
 export enum TimerStatus {
   RUNNING,
   PAUSED,
   STOPPED,
 }
+
 export interface RetroState {
   title: string;
   format: string;
@@ -37,4 +39,5 @@ export interface RetroState {
 }
 
 export type VotesByUserId = Record<string, number>;
+
 export type UserByUserId = Record<string, User>;


### PR DESCRIPTION
# Save Username in Local Storage only at Permission

Issue: #225 

## Acceptance Criteria
- [x] When entering a room, a checkbox with a label "Persist username" is visible 
- [x] Hovering the checkbox and label shows a explanation text
- [x] The checkbox is initially unchecked
- [x] The checkbox state is persisted in local storage
- [x] The checkbox state in local storage is applied at future sessions
- [x] When the checkbox is checked, the username is persisted in local storage

## Description
The local storage of the username is now only applied if the checkbox is checked. The state handling was extracted in its own hook and the textfield with checkbox in its own module to be reused in the create session and join session dialogs.