### PR TITLE
Feature: SBOM Footer Link

### DIFF
--- a/packages/frontend/src/common/components/Footer.tsx
+++ b/packages/frontend/src/common/components/Footer.tsx
@@ -11,6 +11,7 @@ export default function Footer() {
     { href: "https://github.com/MaibornWolff/retro", label: "@Github" },
     { href: "https://github.com/MaibornWolff/retro/issues/new", label: "Report a Bug" },
     { href: "https://www.maibornwolff.de", label: "@MaibornWolff" },
+    { href: "https://github.com/MaibornWolff/retro/network/dependencies", label: "SBOM" },
   ];
   return (
     <footer>


### PR DESCRIPTION
# SBOM Footer Link

The project needs a SBOM and it should be linked in the footer. AS Github provides it per default, only the footer link to github was added.

#295 