### PR TITLE
fix: voting slider starts at one vote

### DIFF
--- a/packages/frontend/src/retro/components/buttons/ImportRetroMenuItem.tsx
+++ b/packages/frontend/src/retro/components/buttons/ImportRetroMenuItem.tsx
@@ -29,7 +29,8 @@ export function ImportRetroMenuItem() {
       participants: {},
       waitingList: {},
       isVotingEnabled: false,
-      cardVotingLimit: 1,
+      maxVoteCount: 1,
+      isMultipleVotesPerCardAllowed: true,
       timerStatus: TimerStatus.STOPPED,
       timerDuration: 0,
     };

--- a/packages/frontend/src/retro/components/cards/UpvoteCardButton.tsx
+++ b/packages/frontend/src/retro/components/cards/UpvoteCardButton.tsx
@@ -14,10 +14,10 @@ interface UpvoteItemButtonProps extends IconButtonProps {
 
 export function UpvoteCardButton({ columnIndex, card, ...props }: UpvoteItemButtonProps) {
   const { retroState, handleUpvoteCard } = useRetroContext();
-  const { cardVotingLimit } = retroState;
+  const { isMultipleVotesPerCardAllowed } = retroState;
   const { user } = useUserContext();
   const votesLeft = useVotesLeft();
-  const votingLimitReached = (card.votes[user.id] ?? 0) >= cardVotingLimit;
+  const votingLimitReached = !isMultipleVotesPerCardAllowed && (card.votes[user.id] ?? 0) >= 1;
   const canUpvote = votesLeft > 0 && !votingLimitReached;
 
   function handleUpvote() {

--- a/packages/frontend/src/retro/components/dialogs/ManageVotesDialog.tsx
+++ b/packages/frontend/src/retro/components/dialogs/ManageVotesDialog.tsx
@@ -24,11 +24,11 @@ export function ManageVotesDialog({ isOpen, close }: DialogProps) {
     handleChangeMaxVote,
     handleResetVotes,
     handleIsVotingEnabledChanged,
-    handleCardVotingLimitChanged,
+    handleIsMultipleVotesPerCardAllowedChanged,
   } = useRetroContext();
   const [voteCount, setVoteCount] = useState(retroState.maxVoteCount);
-  const [isMaxVotesPerCardLimited, setIsMaxVotesPerCardLimited] = useState(
-    retroState.cardVotingLimit === 1,
+  const [isMultipleVotesPerCardAllowed, setIsMultipleVotesPerCardAllowed] = useState(
+    retroState.isMultipleVotesPerCardAllowed,
   );
 
   function handleCancel() {
@@ -40,14 +40,14 @@ export function ManageVotesDialog({ isOpen, close }: DialogProps) {
     setVoteCount(newValue as number);
   }
 
-  function handleVotingLimitChange(event: ChangeEvent<HTMLInputElement>) {
-    setIsMaxVotesPerCardLimited(event.target.checked);
+  function handleIsMultipleVotesPerCardAllowedChange(event: ChangeEvent<HTMLInputElement>) {
+    setIsMultipleVotesPerCardAllowed(event.target.checked);
   }
 
   function handleStart() {
     handleChangeMaxVote(voteCount);
     handleIsVotingEnabledChanged(true);
-    handleCardVotingLimitChanged(isMaxVotesPerCardLimited ? 1 : Number.MAX_VALUE);
+    handleIsMultipleVotesPerCardAllowedChanged(isMultipleVotesPerCardAllowed);
     close();
   }
 
@@ -67,7 +67,7 @@ export function ManageVotesDialog({ isOpen, close }: DialogProps) {
       aria-labelledby="vote-count-dialog"
       aria-describedby="vote-count-dialog-description"
     >
-      <DialogTitle id="vote-count-dialog">Vote Count Settings</DialogTitle>
+      <DialogTitle id="vote-count-dialog">Voting Settings</DialogTitle>
       <DialogContent>
         <FormControl fullWidth>
           <Typography id="vote-count-label" gutterBottom>
@@ -79,18 +79,23 @@ export function ManageVotesDialog({ isOpen, close }: DialogProps) {
             valueLabelDisplay="auto"
             aria-labelledby="vote-count-slider"
             getAriaValueText={getValueText}
+            defaultValue={1}
             min={1}
             max={10}
+            marks
           />
         </FormControl>
         <Typography variant="body1">
-          Everybody has <strong>{voteCount}</strong> votes
+          Everybody has <strong>{voteCount}</strong> {voteCount === 1 ? "vote" : "votes"}
         </Typography>
         <FormControlLabel
           control={
-            <Checkbox checked={isMaxVotesPerCardLimited} onChange={handleVotingLimitChange} />
+            <Checkbox
+              checked={isMultipleVotesPerCardAllowed}
+              onChange={handleIsMultipleVotesPerCardAllowedChange}
+            />
           }
-          label="Maximum one vote per card"
+          label="Allow multiple votes per card"
         />
       </DialogContent>
       <DialogActions>

--- a/packages/frontend/src/retro/context/RetroContext.tsx
+++ b/packages/frontend/src/retro/context/RetroContext.tsx
@@ -44,11 +44,11 @@ const initialState: RetroState = {
   format: "",
   columns: [],
   isBlurred: false,
-  maxVoteCount: 0,
+  maxVoteCount: 1,
   participants: {},
   waitingList: {},
   isVotingEnabled: false,
-  cardVotingLimit: 1,
+  isMultipleVotesPerCardAllowed: true,
   timerStatus: TimerStatus.STOPPED,
   timerDuration: 0,
 };
@@ -83,7 +83,7 @@ export interface RetroContextValues {
   handleAcceptJoinUser: (userId: string) => void;
   handleAddToWaitingList: (payload: AddToWaitingListAction["payload"]) => void;
   handleIsVotingEnabledChanged: (isEnabled: boolean) => void;
-  handleCardVotingLimitChanged: (limit: number) => void;
+  handleIsMultipleVotesPerCardAllowedChanged: (isAllowed: boolean) => void;
   handleStartTimer: (duration: number) => void;
   handlePauseTimer: () => void;
   handleChangeTimer: (duration: number) => void;
@@ -231,8 +231,8 @@ export function RetroContextProvider(props: RetroContextProviderProps) {
     dispatchAndBroadcast({ type: "IS_VOTING_ENABLED_CHANGED", isEnabled });
   }
 
-  function handleCardVotingLimitChanged(limit: number) {
-    dispatchAndBroadcast({ type: "CARD_VOTING_LIMIT_CHANGED", limit });
+  function handleIsMultipleVotesPerCardAllowedChanged(isAllowed: boolean) {
+    dispatchAndBroadcast({ type: "IS_MULTIPLE_VOTES_PER_CARD_ALLOWED_CHANGED", isAllowed });
   }
 
   function handleStartTimer(duration: StartTimerAction["duration"]) {
@@ -289,7 +289,7 @@ export function RetroContextProvider(props: RetroContextProviderProps) {
     handleAcceptJoinUser: acceptJoinUser,
     handleAddToWaitingList,
     handleIsVotingEnabledChanged,
-    handleCardVotingLimitChanged,
+    handleIsMultipleVotesPerCardAllowedChanged,
     handleStartTimer,
     handlePauseTimer,
     handleStopTimer,

--- a/packages/frontend/src/retro/context/RetroContext.tsx
+++ b/packages/frontend/src/retro/context/RetroContext.tsx
@@ -33,7 +33,6 @@ import { useUserContext } from "../../common/context/UserContext";
 import { useErrorContext } from "../../common/context/ErrorContext";
 import { useSyncUser } from "../../common/hooks/useSyncUser";
 import { ErrorState } from "../../common/types/commonTypes";
-import { useConfigurationContext } from "../../common/context/ConfigurationContext";
 
 interface RetroContextProviderProps {
   children?: React.ReactNode;
@@ -94,8 +93,7 @@ export interface RetroContextValues {
 export const RetroContext = React.createContext<RetroContextValues>(undefined!);
 
 export function RetroContextProvider(props: RetroContextProviderProps) {
-  const { maxVoteCount } = useConfigurationContext().retro;
-  const [state, dispatch] = useReducer(retroReducer, { ...initialState, maxVoteCount });
+  const [state, dispatch] = useReducer(retroReducer, { ...initialState });
   const { user } = useUserContext();
   const { setError } = useErrorContext();
 

--- a/packages/frontend/src/retro/reducers/retroReducer.ts
+++ b/packages/frontend/src/retro/reducers/retroReducer.ts
@@ -224,8 +224,8 @@ export const retroReducer = (state: RetroState, action: RetroAction): RetroState
     case "IS_VOTING_ENABLED_CHANGED": {
       return { ...state, isVotingEnabled: action.isEnabled };
     }
-    case "CARD_VOTING_LIMIT_CHANGED": {
-      return { ...state, cardVotingLimit: action.limit };
+    case "IS_MULTIPLE_VOTES_PER_CARD_ALLOWED_CHANGED": {
+      return { ...state, isMultipleVotesPerCardAllowed: action.isAllowed };
     }
     case "START_TIMER": {
       return {

--- a/packages/frontend/src/retro/types/retroActions.ts
+++ b/packages/frontend/src/retro/types/retroActions.ts
@@ -17,6 +17,11 @@ export interface MaxVoteChangeAction extends BaseAction {
   payload: number;
 }
 
+export interface IsMultipleVotesPerCardAllowedChangedAction extends BaseAction {
+  type: "IS_MULTIPLE_VOTES_PER_CARD_ALLOWED_CHANGED";
+  isAllowed: boolean;
+}
+
 export interface VoteResetAction extends BaseAction {
   type: "VOTE_RESET";
 }
@@ -123,6 +128,7 @@ export type RetroAction =
   | CardUpvoteAction
   | CardRemoveUpvoteAction
   | MaxVoteChangeAction
+  | IsMultipleVotesPerCardAllowedChangedAction
   | VoteResetAction
   | SetRetroStateAction
   | HighlightCardAction

--- a/packages/frontend/src/retro/types/retroTypes.ts
+++ b/packages/frontend/src/retro/types/retroTypes.ts
@@ -33,7 +33,7 @@ export interface RetroState {
   participants: UserByUserId;
   waitingList: UserByUserId;
   isVotingEnabled: boolean;
-  cardVotingLimit: number;
+  isMultipleVotesPerCardAllowed: boolean;
   timerStatus: TimerStatus;
   timerDuration: number;
 }

--- a/packages/shared/configuration/src/configuration.ts
+++ b/packages/shared/configuration/src/configuration.ts
@@ -18,9 +18,6 @@ export function getConfiguration(): ApplicationConfiguration {
     logLevel: validateLogLevel(process.env.LOG_LEVEL) ?? "info",
     backendUrl,
     signalingServerUrl,
-    retro: {
-      maxVoteCount: Number(process.env.RETRO_MAX_VOTE_COUNT) ?? 3,
-    },
     corsOrigins: parseCorsOrigins(process.env.CORS_ORIGIN) ?? "*",
     iceServerUrls: parseIceServers(process.env.ICE_SERVER_URLS) ?? [
       { url: "stun:stun.l.google.com:19302" },

--- a/packages/shared/configuration/src/types.ts
+++ b/packages/shared/configuration/src/types.ts
@@ -7,14 +7,9 @@ export type LogLevel = "info" | "warn" | "error" | "debug";
 export interface ApplicationConfiguration {
   logLevel: LogLevel;
   backendUrl: RetroAppUrl;
-  retro: RetroConfiguration;
   signalingServerUrl: RetroAppUrl;
   corsOrigins: CorsOrigins;
   iceServerUrls: IceServerConfiguration[];
-}
-
-export interface RetroConfiguration {
-  maxVoteCount: number;
 }
 
 export interface IceServerConfiguration {


### PR DESCRIPTION
# Voting slider starts at 1

Issue: #206 

## Description

This PR changes the votes slider to start at value 1 instead of 0.
Also there are some slight changes in the retro state handling and the ui:
- the card voting limit has been changed to a boolean isMultipleVotesPerCardAllowed. I don't think there is a use case for limiting the votes per card to another value than one and in the other case limiting it to infitniy felt weird.
- I found it easier to understand when inverted. I also made that change in the UI offering a checkbox with the text "Allow multiple votes per card" that is set to true by default.
- there are now marks on the votes slider to indicate where the values change.
- when there is only one vote per user, the text uses "vote" instead of "votes"
- the headline now says "Voting Settings" instead of "Vote Count Settings" because you can control more in that modal than just the count.
- the shared config for maxVoteCount has been removed
